### PR TITLE
Add "export" to pass variable to subprocess

### DIFF
--- a/src/os_common/lib/CommandExecuterFloat.cpp
+++ b/src/os_common/lib/CommandExecuterFloat.cpp
@@ -31,7 +31,7 @@ namespace omni
     {
         std::stringstream ss;
 
-        ss << "OMNITHING_FLOAT_VAL=" << val << "; " << m_CommandStr;
+        ss << "export OMNITHING_FLOAT_VAL=" << val << "; " << m_CommandStr;
         std::string s = ss.str();
 
         if(m_bMultithreaded)


### PR DESCRIPTION
I'm using Pi 3 with Raspbian GNU/Linux 9 (stretch), and the command execution cannot pass environment variable to subprocess of popen. Adding "export" would fix this issue.
Tested and verified on my own machine with dimmer switch.